### PR TITLE
Fix Incorrect Package Name and Version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 falkordb==1.0.4
 openai==1.23.6
-pinecone==0.1.0
+pinecone-client==3.2.2
 tqdm==4.66.1


### PR DESCRIPTION
**Summary**
This pull request updates the requirements.txt file to correct an error that occurs during package installation. The entry for pinecone has been updated to the correct package name pinecone-client and to a valid version 3.2.2.

**Changes**
Changed pinecone==0.1.0 to pinecone-client==3.2.2 in requirements.txt.

**Impact**
This change resolves the installation error that prevents the successful installation of required dependencies. By updating to the correct package name and a valid version, users and developers can now install all dependencies smoothly without errors.

**Justification**
The error was identified during routine installation checks, where pip could not find the package pinecone==0.1.0 because the correct package name is pinecone-client. The version was also updated to 3.2.2 based on the latest available version in the Python Package Index (PyPI) that supports the current project setup.

**Additional Information**
The update ensures compatibility and functionality of the dependencies required for the project, improving the setup process for new developers and in continuous integration environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the `pinecone-client` package to version `3.2.2` to enhance app functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->